### PR TITLE
Change cache getting and setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ include
 docs/_build
 build/
 .tox
+.cache
+.coverage

--- a/cachecontrol/adapter.py
+++ b/cachecontrol/adapter.py
@@ -9,7 +9,7 @@ from .filewrapper import CallbackFileWrapper
 
 
 class CacheControlAdapter(HTTPAdapter):
-    invalidating_methods = set(['PUT', 'DELETE'])
+    invalidating_methods = set(['PUT', 'PATCH', 'DELETE'])
 
     def __init__(self, cache=None,
                  cache_etags=True,
@@ -117,8 +117,8 @@ class CacheControlAdapter(HTTPAdapter):
 
         # See if we should invalidate the cache.
         if request.method in self.invalidating_methods and resp.ok:
-            cache_url = self.controller.cache_url(request.url)
-            self.cache.delete(cache_url)
+            cache_key = self.controller.cache_key(request)
+            self.cache.delete(cache_key)
 
         # Give the request a from_cache attr to let people use it
         resp.from_cache = from_cache

--- a/cachecontrol/cache.py
+++ b/cachecontrol/cache.py
@@ -37,3 +37,28 @@ class DictCache(BaseCache):
         with self.lock:
             if key in self.data:
                 self.data.pop(key)
+
+
+CACHE_KEY_DELIMTER = ';'
+
+
+def keymaker(prefix, suffix=''):
+    """Given a prefix and an optional suffix, create a cache key
+
+    The purpose of the suffix and DELIMTER is to allow two kinds of cache key
+    - public level keys that are available to all users and user level keys
+    where the suffix is used to identify said user
+    """
+    fmt = "{}{}{}" if suffix else "{}"
+    return fmt.format(prefix, CACHE_KEY_DELIMTER, suffix)
+
+
+def keybreaker(key):
+    """Given a cache key, return the prefix and suffix used to create it"""
+    split = key.split(CACHE_KEY_DELIMTER)
+    prefix = split[0]
+    try:
+        suffix = split[1]
+    except IndexError:
+        suffix = ''
+    return prefix, suffix

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -7,5 +7,6 @@ mock
 cherrypy
 sphinx
 redis
+fakeredis
 lockfile
 bumpversion

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,12 @@
+import pytest
+from cachecontrol.cache import keymaker, keybreaker
+
+
+@pytest.mark.parametrize('prefix, suffix', [
+    ('thisisprefix', 'andthisissuffix'),
+    ('thisisprefix', ''),
+    ('', 'andthisissuffix'),
+    ('', ''),
+])
+def test_keymaking_is_inverse_of_keybreaking(prefix, suffix):
+    assert keybreaker(keymaker(prefix, suffix)) == (prefix, suffix)

--- a/tests/test_storage_redis.py
+++ b/tests/test_storage_redis.py
@@ -2,14 +2,75 @@ from datetime import datetime
 
 from mock import Mock
 from cachecontrol.caches import RedisCache
+from cachecontrol.cache import keymaker
+import fakeredis
+import pytest
 
 
 class TestRedisCache(object):
 
     def setup(self):
-        self.conn = Mock()
+        self.conn = Mock(spec=fakeredis.FakeStrictRedis())
         self.cache = RedisCache(self.conn)
 
     def test_set_expiration(self):
-        self.cache.set('foo', 'bar', expires=datetime(2014, 2, 2))
+        self.cache.set('foo', 'bar', expires=datetime(2099, 2, 2))
         assert self.conn.setex.called
+
+
+class TestRedisCacheGetSemantics(object):
+    def setup(self):
+        self.cache = RedisCache(fakeredis.FakeStrictRedis())
+
+    def teardown(self):
+        self.cache.clear()
+
+    @pytest.mark.parametrize("key, value, expected", [
+        ("key-a", 100, b'100'),
+        ("key-b", 948, b'948'),
+        ("key-b;deadbeef", 3, b'3'),
+        ("this;other", 0, b'0'),
+        ("key-b;other", '', b''),
+    ])
+    def test_get_returns_key_if_it_exists(self, key, value, expected):
+        self.cache.set(key, value)
+        assert self.cache.get(key) == expected
+
+    def test_get_prefers_non_separated_key_if_both_are_set(self):
+        # we use keys in two formats - url + url;some-identifier
+        # if keys in both format are set we default to using the shorter format
+        self.cache.set('this;and-that', 4)
+        self.cache.set('this', 44)
+        assert self.cache.get('this;and-that') == b'44'
+
+    @pytest.mark.parametrize("prefix, suffix, prefix_value, combined_value, expected", [
+        ("this", "other", 0, '', b'0'),
+        ("this", "other", '', 0, b''),
+        ("this", "other", False, 0, b'False'),
+    ])
+    def test_get_when_both_values_are_falsey(self, prefix, suffix, prefix_value, combined_value, expected):
+        combined_key = keymaker(prefix, suffix)
+        self.cache.set(prefix, prefix_value)
+        self.cache.set(combined_key, combined_value)
+        assert self.cache.get(combined_key) == expected
+
+
+class TestRedisCacheDeleteSemantics(object):
+    def setup(self):
+        self.cache = RedisCache(fakeredis.FakeStrictRedis())
+
+    def teardown(self):
+        self.cache.clear()
+
+    def test_deleting_suffixed_key_also_deletes_short_key(self):
+        self.cache.set('this;and-that', 4)
+        self.cache.set('this', 44)
+        self.cache.delete('this;and-that')
+        assert self.cache.get('this') is None
+
+    def test_deleting_short_key_deletes_all_suffixed_versions(self):
+        self.cache.set('this;foobarbaz', 4)
+        self.cache.set('this;and-that', 4)
+        self.cache.set('this', 44)
+        self.cache.delete('this')
+        assert len(self.cache.keys()) == 0


### PR DESCRIPTION
The gateway api caches requests made to the other internal api endpoints
but by default cachecontrol caches these requests by their url. We want
to include a user's auth token in the cache key (for private requests)
so that we can cache by user.

When reading from the cache we now always use the authorization header
to build the cache key in conjunction with the request.url. When
actually reading from the backend store we rely on redis' mget method to
request both versions of the key (with and without the hash of the auth
header) and return the first value we find. We are biased towards keys
that do NOT include the auth hash but in practice public/private should
be a binary switch and so there should never be an issue of a less
preferred key being returned.

When writing to the cache we examine the response when creating a cache
key to determine if the response is private or public so we can set an
appropriate cache key

https://thephysicalnetwork.atlassian.net/browse/RO-586