### PR TITLE
NAMB-53 Add test matrix for authorized/unauthorized @ get/set

### DIFF
--- a/tests/test_storage_redis.py
+++ b/tests/test_storage_redis.py
@@ -54,6 +54,22 @@ class TestRedisCacheGetSemantics(object):
         self.cache.set(combined_key, combined_value)
         assert self.cache.get(combined_key) == expected
 
+    @pytest.mark.parametrize("value_auth, value, expected_auth, expected", [
+        (None, None, None, None),
+        ('sensitive-data', None, b'sensitive-data', None),
+        (None, 'foo', b'foo', b'foo'),
+        ('sensitive-data', 'foo', b'foo', b'foo'),
+    ])
+    def test_get_set_matrix(self, value_auth, value, expected_auth, expected):
+        if value_auth is not None:
+            self.cache.set("url;auth-hash", value_auth)
+
+        if value is not None:
+            self.cache.set("url", value)
+
+        assert self.cache.get("url;auth-hash") == expected_auth
+        assert self.cache.get("url") == expected
+
 
 class TestRedisCacheDeleteSemantics(object):
     def setup(self):


### PR DESCRIPTION
@kirberich @olasitarska 

```bash
$ pytest tests/
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.5.2, pytest-3.0.7, py-1.4.33, pluggy-0.4.0
rootdir: /var/alex/www/cachecontrol, inifile: setup.cfg
collected 103 items 

tests/test_adapter.py .........
tests/test_cache.py ....
tests/test_cache_control.py ......................
tests/test_chunked_response.py ...
tests/test_etag.py ...
tests/test_expires_heuristics.py ................
tests/test_max_age.py ..
tests/test_redirects.py ....
tests/test_regressions.py ..
tests/test_serialization.py ..........
tests/test_server_http_version.py .
tests/test_storage_filecache.py .........
tests/test_storage_redis.py ................
tests/test_stream.py .
tests/test_vary.py .

======================================================================================= 103 passed in 11.13 seconds ========================================================================================
[19/May/2017:15:15:00] ENGINE HTTP Server cherrypy._cpwsgi_server.CPWSGIServer(('127.0.0.1', 47818)) shut down

```